### PR TITLE
Update style.css

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -34,7 +34,7 @@ html,
 body {
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
Deactivation of the overflow on the X-axis, while still maintaining the overflow on the Y-axis.

Today (without this fix) it is not possible to use vertical scrolling, so by opening raw or having a browser with a not too tall view, it is not possible to scroll.
